### PR TITLE
Hide Tenacity's AttemptManager from the users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Changed
 
-- Tenacity's internal attempt object is no longer exposed to the user.
+- Tenacity's internal `AttemptManager` object is no longer exposed to the user.
   This was an oversight and never documented.
   `stamina.retry_context()` now yields instances of `stamina.Attempt`.
   [#22](https://github.com/hynek/stamina/pull/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Tenacity's internal attempt object is no longer exposed to the user.
   This was an oversight and never documented.
   `stamina.retry_context()` now yields instances of `stamina.Attempt`.
+  [#22](https://github.com/hynek/stamina/pull/22)
 
 
 ## [23.1.0](https://github.com/hynek/stamina/compare/22.2.0...23.1.0) - 2023-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/stamina/compare/23.1.0...HEAD)
 
+### Changed
+
+- Tenacity's internal attempt object is no longer exposed to the user.
+  This was an oversight and never documented.
+  `stamina.retry_context()` now yields instances of `stamina.Attempt`.
+
 
 ## [23.1.0](https://github.com/hynek/stamina/compare/22.2.0...23.1.0) - 2023-07-04
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@ API Reference
 .. autofunction:: retry
 .. autofunction:: retry_context
 .. autoclass:: Attempt
+   :members: num
 
 
 Configuration

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,7 @@ API Reference
 
 .. autofunction:: retry
 .. autofunction:: retry_context
+.. autoclass:: Attempt
 
 
 Configuration

--- a/src/stamina/__init__.py
+++ b/src/stamina/__init__.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 from ._config import is_active, set_active
-from ._core import retry, retry_context
+from ._core import Attempt, retry, retry_context
 from ._instrumentation import RETRY_COUNTER
 
 
 __all__ = [
+    "Attempt",
     "retry",
     "retry_context",
     "is_active",

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -81,6 +81,13 @@ class Attempt:
 
     _t_attempt: _t.AttemptManager
 
+    @property
+    def num(self) -> int:
+        """
+        The number of the current attempt.
+        """
+        return self._t_attempt.retry_state.attempt_number  # type: ignore[no-any-return]
+
     def __enter__(self) -> None:
         return self._t_attempt.__enter__()  # type: ignore[no-any-return]
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -210,21 +210,16 @@ class _RetryContextIterator:
 
     async def __anext__(self) -> Attempt:
         while True:
-            do = self._t_a_retrying.iter(
-                retry_state=self._t_a_retrying._retry_state
-            )
-            if do is None:
+            rs = self._t_a_retrying._retry_state
+            if (do := self._t_a_retrying.iter(retry_state=rs)) is None:
                 raise StopAsyncIteration
 
             if isinstance(do, _t.DoAttempt):
-                return Attempt(
-                    _t.AttemptManager(
-                        retry_state=self._t_a_retrying._retry_state
-                    )
-                )
+                return Attempt(_t.AttemptManager(retry_state=rs))
 
             if isinstance(do, _t.DoSleep):
-                self._t_a_retrying._retry_state.prepare_for_next_attempt()
+                rs.prepare_for_next_attempt()
+
                 await self._t_a_retrying.sleep(do)
             else:
                 raise StopAsyncIteration  # pragma: no cover -- no clue how to trigger

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -103,7 +103,7 @@ class _LazyNoAsyncRetry:
     Allows us a free null object pattern using non-retries and avoid None.
     """
 
-    def __aiter__(self) -> _t.StopBase:
+    def __aiter__(self) -> _t.AsyncRetrying:
         return _t.AsyncRetrying(reraise=True, stop=_STOP_NO_RETRY).__aiter__()
 
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -12,12 +12,7 @@ from dataclasses import dataclass, replace
 from functools import wraps
 from inspect import iscoroutinefunction
 from types import TracebackType
-from typing import (
-    AsyncIterator,
-    Iterable,
-    Iterator,
-    TypeVar,
-)
+from typing import AsyncIterator, Iterable, Iterator, TypeVar
 
 import tenacity as _t
 
@@ -210,23 +205,7 @@ class _RetryContextIterator:
         return self
 
     async def __anext__(self) -> Attempt:
-        # XXX: This is a reimplementation of `tenacity.AsyncRetrying.__anext__`
-        # XXX: as of 433324956abb028f6d993195d31e4dd8308115c3. I'm open to
-        # XXX: suggestions on how to wrap it instead.
-        while True:
-            rs = self._t_a_retrying._retry_state
-            if (do := self._t_a_retrying.iter(retry_state=rs)) is None:
-                raise StopAsyncIteration
-
-            if isinstance(do, _t.DoAttempt):
-                return Attempt(_t.AttemptManager(retry_state=rs))
-
-            if isinstance(do, _t.DoSleep):
-                rs.prepare_for_next_attempt()
-
-                await self._t_a_retrying.sleep(do)
-            else:
-                raise StopAsyncIteration  # pragma: no cover -- no clue how to trigger
+        return Attempt(await self._t_a_retrying.__anext__())
 
 
 def _make_before_sleep(

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -204,8 +204,8 @@ class _RetryContextIterator:
 
     async def __anext__(self) -> Attempt:
         # XXX: This is a reimplementation of `tenacity.AsyncRetrying.__anext__`
-        # as of 433324956abb028f6d993195d31e4dd8308115c3 because I can't come
-        # up with a good way to wrap it.`
+        # XXX: as of 433324956abb028f6d993195d31e4dd8308115c3. I'm open to
+        # XXX: suggestions on how to wrap it instead.
         while True:
             rs = self._t_a_retrying._retry_state
             if (do := self._t_a_retrying.iter(retry_state=rs)) is None:

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -98,6 +98,18 @@ class Attempt:
 _STOP_NO_RETRY = _t.stop_after_attempt(1)
 
 
+class _LazyNoAsyncRetry:
+    """
+    Allows us a free null object pattern using non-retries and avoid None.
+    """
+
+    def __aiter__(self) -> _t.StopBase:
+        return _t.AsyncRetrying(reraise=True, stop=_STOP_NO_RETRY).__aiter__()
+
+
+_LAZY_NO_ASYNC_RETRY = _LazyNoAsyncRetry()
+
+
 @dataclass
 class _RetryContextIterator:
     __slots__ = (
@@ -153,7 +165,7 @@ class _RetryContextIterator:
                 ),
                 "reraise": True,
             },
-            _t_a_retrying=_t.AsyncRetrying(reraise=True, stop=_STOP_NO_RETRY),
+            _t_a_retrying=_LAZY_NO_ASYNC_RETRY,
         )
 
     def with_name(

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -209,6 +209,9 @@ class _RetryContextIterator:
         return self
 
     async def __anext__(self) -> Attempt:
+        # XXX: This is a reimplementation of `tenacity.AsyncRetrying.__anext__`
+        # as of 433324956abb028f6d993195d31e4dd8308115c3 because I can't come
+        # up with a good way to wrap it.`
         while True:
             rs = self._t_a_retrying._retry_state
             if (do := self._t_a_retrying.iter(retry_state=rs)) is None:

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -112,13 +112,7 @@ _LAZY_NO_ASYNC_RETRY = _LazyNoAsyncRetry()
 
 @dataclass
 class _RetryContextIterator:
-    __slots__ = (
-        "_t_kw",
-        "_t_a_retrying",
-        "_name",
-        "_args",
-        "_kw",
-    )
+    __slots__ = ("_t_kw", "_t_a_retrying", "_name", "_args", "_kw")
     _t_kw: dict[str, object]
     _t_a_retrying: _t.AsyncRetrying
     _name: str

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -151,6 +151,9 @@ async def test_retry_block():
     async for attempt in stamina.retry_context(on=ValueError, wait_max=0):
         with attempt:
             num_called += 1
+
+            assert num_called == attempt.num
+
             if num_called < 2:
                 raise ValueError
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -124,6 +124,24 @@ async def test_retry_inactive():
     assert 1 == num_called
 
 
+async def test_retry_inactive_ok():
+    """
+    If inactive, the happy path still works.
+    """
+    num_called = 0
+
+    @stamina.retry(on=Exception)
+    async def f():
+        nonlocal num_called
+        num_called += 1
+
+    stamina.set_active(False)
+
+    await f()
+
+    assert 1 == num_called
+
+
 async def test_retry_block():
     """
     Async retry_context blocks are retried.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -97,6 +97,24 @@ def test_retry_inactive():
     assert 1 == num_called
 
 
+def test_retry_inactive_ok():
+    """
+    If inactive, the happy path still works.
+    """
+    num_called = 0
+
+    @stamina.retry(on=Exception)
+    def f():
+        nonlocal num_called
+        num_called += 1
+
+    stamina.set_active(False)
+
+    f()
+
+    assert 1 == num_called
+
+
 def test_retry_block():
     """
     Sync retry_context blocks are retried.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -124,6 +124,9 @@ def test_retry_block():
     for attempt in stamina.retry_context(on=ValueError, wait_max=0):
         with attempt:
             i += 1
+
+            assert i == attempt.num
+
             if i < 2:
                 raise ValueError
 

--- a/tests/typing/api.py
+++ b/tests/typing/api.py
@@ -98,7 +98,7 @@ def hook(
 
 for attempt in retry_context(on=ValueError, timeout=13):
     with attempt:
-        ...
+        x: int = attempt.num
 
 for attempt in retry_context(
     on=ValueError, timeout=dt.timedelta(seconds=13.0)
@@ -116,4 +116,4 @@ async def f() -> None:
         wait_jitter=one_sec,
     ):
         with attempt:
-            ...
+            pass


### PR DESCRIPTION
I'm unhappy with the `__anext__` implementation, but I'm not sure it's possible to wrap [this code](https://github.com/jd/tenacity/blob/433324956abb028f6d993195d31e4dd8308115c3/tenacity/_asyncio.py#L69-L80) more elegantly?