### PR TITLE
Use stdlib logging if structlog is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/stamina/compare/23.1.0...HEAD)
 
+### Added
+
+- If *structlog* is not installed, the scheduled retry is logged using the standard library `logging` module.
+
+
 ### Changed
 
 - Tenacity's internal `AttemptManager` object is no longer exposed to the user.
@@ -23,7 +28,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#22](https://github.com/hynek/stamina/pull/22)
 
 - Initialization of instrumentation is now delayed.
-  This means that if there's no retries, there's no startup overhead from importing *structlog* and *prometheus_client*.
+  This means that if there's no retries, there's no startup overhead from importing *structlog* and *prometheus-client*.
   [#34](https://github.com/hynek/stamina/pull/34)
 
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -16,10 +16,8 @@ from typing import AsyncIterator, Iterator, TypeVar
 
 import tenacity as _t
 
-from stamina.typing import RetryDetails
-
 from ._config import _CONFIG, _Config
-from ._instrumentation import guess_name
+from ._instrumentation import RetryDetails, guess_name
 
 
 if sys.version_info >= (3, 10):
@@ -216,9 +214,6 @@ def _make_before_sleep(
     """
 
     def before_sleep(rcs: _t.RetryCallState) -> None:
-        if not (on_retry := config.on_retry):
-            return
-
         details = RetryDetails(
             name=name,
             attempt=rcs.attempt_number,
@@ -228,7 +223,7 @@ def _make_before_sleep(
             kwargs=kw,
         )
 
-        for hook in on_retry:
+        for hook in config.on_retry:
             hook(details)
 
     return before_sleep

--- a/src/stamina/_instrumentation.py
+++ b/src/stamina/_instrumentation.py
@@ -4,7 +4,36 @@
 
 from __future__ import annotations
 
-from .typing import RetryDetails, RetryHook
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class RetryDetails:
+    """
+    Details about a retry attempt that are passed into :class:`RetryHook`s.
+
+    .. versionadded:: 23.2.0
+    """
+
+    name: str
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+    attempt: int
+    idle_for: float
+    exception: Exception
+
+
+class RetryHook(Protocol):
+    """
+    A callable that gets called after an attempt has failed and a retry has
+    been scheduled.
+
+    .. versionadded:: 23.2.0
+    """
+
+    def __call__(self, details: RetryDetails) -> None:
+        ...
 
 
 def get_default_hooks() -> tuple[RetryHook, ...]:
@@ -16,8 +45,7 @@ def get_default_hooks() -> tuple[RetryHook, ...]:
     if prom := init_prometheus():
         hooks.append(prom)
 
-    if sl := init_structlog():
-        hooks.append(sl)
+    hooks.append(init_structlog() or init_logging(30))
 
     return tuple(hooks)
 
@@ -30,6 +58,8 @@ def init_prometheus() -> RetryHook | None:
     Try to initialize Prometheus instrumentation.
 
     Return None if it's not available.
+
+    .. versionadded:: 23.2.0
     """
     try:
         from prometheus_client import Counter
@@ -64,6 +94,8 @@ def init_structlog() -> RetryHook | None:
     Try to initialize structlog instrumentation.
 
     Return None if it's not available.
+
+    .. versionadded:: 23.2.0
     """
     try:
         import structlog
@@ -77,10 +109,39 @@ def init_structlog() -> RetryHook | None:
             "stamina.retry_scheduled",
             callable=details.name,
             attempt=details.attempt,
-            slept=details.idle_for,
+            idle_for=details.idle_for,
             error=repr(details.exception),
             args=tuple(repr(a) for a in details.args),
             kwargs=dict(details.kwargs.items()),
+        )
+
+    return log_retries
+
+
+def init_logging(log_level: int) -> RetryHook:
+    """
+    Initialize logging using the standard library.
+
+    Returned hook logs scheduled retries at *log_level*.
+
+    .. versionadded:: 23.2.0
+    """
+    import logging
+
+    logger = logging.getLogger("stamina")
+
+    def log_retries(details: RetryDetails) -> None:
+        logger.log(
+            log_level,
+            "stamina.retry_scheduled",
+            extra={
+                "stamina.callable": details.name,
+                "stamina.args": tuple(repr(a) for a in details.args),
+                "stamina.kwargs": dict(details.kwargs.items()),
+                "stamina.attempt": details.attempt,
+                "stamina.idle_for": details.idle_for,
+                "stamina.error": repr(details.exception),
+            },
         )
 
     return log_retries

--- a/src/stamina/typing.py
+++ b/src/stamina/typing.py
@@ -4,29 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+from ._instrumentation import RetryDetails, RetryHook
 
 
-@dataclass(frozen=True)
-class RetryDetails:
-    """
-    Details about a retry attempt that are passed into :class:`RetryHook`s.
-    """
-
-    name: str
-    attempt: int
-    idle_for: float
-    exception: Exception
-    args: tuple[object, ...]
-    kwargs: dict[str, object]
-
-
-class RetryHook(Protocol):
-    """
-    A callable that gets called after an attempt has failed and a retry has
-    been scheduled.
-    """
-
-    def __call__(self, details: RetryDetails) -> None:
-        ...
+__all__ = ["RetryHook", "RetryDetails"]

--- a/tests/test_structlog.py
+++ b/tests/test_structlog.py
@@ -36,7 +36,7 @@ def test_decorator_sync(log_output):
         {
             "args": (),
             "attempt": 1,
-            "slept": 0.0,
+            "idle_for": 0.0,
             "callable": "tests.test_structlog.test_decorator_sync.<locals>.f",
             "error": "ValueError()",
             "event": "stamina.retry_scheduled",
@@ -62,7 +62,7 @@ async def test_decorator_async(log_output):
         {
             "args": (),
             "attempt": 1,
-            "slept": 0.0,
+            "idle_for": 0.0,
             "callable": "tests.test_structlog.test_decorator_async.<locals>.f",
             "error": "ValueError()",
             "event": "stamina.retry_scheduled",
@@ -84,7 +84,7 @@ def test_context_sync(log_output):
         {
             "callable": "<context block>",
             "attempt": 1,
-            "slept": 0.0,
+            "idle_for": 0.0,
             "error": "ValueError()",
             "args": (),
             "kwargs": {},
@@ -106,7 +106,7 @@ async def test_context_async(log_output):
         {
             "callable": "<context block>",
             "attempt": 1,
-            "slept": 0.0,
+            "idle_for": 0.0,
             "error": "ValueError()",
             "args": (),
             "kwargs": {},


### PR DESCRIPTION
Before I tackle configurability, here's stdlib logging by default if structlog is missing (should never happen but the world is what it is).

Does this look OK to you @estahn?

Ref https://github.com/hynek/stamina/discussions/29