### PR TITLE
Prevent unbounded stop condition

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -125,7 +125,7 @@ You will find the built documentation in `docs/_build/html`.
   We follow CalVer, so the next version will be the current with with the middle number incremented (for example, `24.1.0` -> `24.2.0`).
 
 - We use [Ruff](https://ruff.rs/) to sort our imports and format our code with a line length of 79 characters.
-  As long as you run our full *tox* suite before committing, or install our [*pre-commit*](https://pre-commit.com/) hooks (ideally you'll do both -- see [*Local Development Environment*](#local-development-environment) above), you won't have to spend any time on formatting your code at all.
+  As long as you run our full *nox* suite before committing, or install our [*pre-commit*](https://pre-commit.com/) hooks (ideally you'll do both -- see [*Local Development Environment*](#local-development-environment) above), you won't have to spend any time on formatting your code at all.
   If you don't, CI will catch it for you -- but that seems like a waste of your time!
 
 
@@ -140,7 +140,7 @@ You will find the built documentation in `docs/_build/html`.
   assert "foo" == x._a_private_attribute
   ```
 
-- You can run  the test suite runs with all (optional) dependencies against all supported Python versions just as it will in our CI by running `tox`.
+- You can run  the test suite runs with all (optional) dependencies against all supported Python versions just as it will in our CI by running `nox`.
 
 - Write [good test docstrings](https://jml.io/test-docstrings/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 ### Changed
 
 - Raise `ValueError` when *attempts* and *timeout* are both `None` to prevent unbounded stop conditions.
-  [#101](https://github.com/hynek/stamina/pull/101)
+  [#102](https://github.com/hynek/stamina/pull/102)
 
 
 ## [25.1.0](https://github.com/hynek/stamina/compare/24.3.0...25.1.0) - 2025-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Changed
 
-- Raise `ValueError` when *attempts* and *timeout* are both `None` to prevent unbounded stop conditions.
+- Raise `ValueError` when *attempts* and *timeout* are both `None` to prevent unbounded stop condition.
+  [#102](https://github.com/hynek/stamina/pull/102)
+
+
+### Fixed
+
+- Prevent unbounded stop condition when both *attempts* and *timeout* are falsy.
   [#102](https://github.com/hynek/stamina/pull/102)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/stamina/compare/25.1.0...HEAD)
 
+### Changed
+
+- Raise `ValueError` when *attempts* and *timeout* are both `None` to prevent unbounded stop conditions.
+  [#101](https://github.com/hynek/stamina/pull/101)
+
 
 ## [25.1.0](https://github.com/hynek/stamina/compare/24.3.0...25.1.0) - 2025-03-12
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -637,25 +637,23 @@ def _make_before_sleep(
     return before_sleep
 
 
-def _make_stop(*, attempts: int | None, timeout: float | None) -> _t.stop_base:
+def _make_stop(*, attempts: int | None, timeout: float | None) -> _t.stop_any:
     """
     Combine *attempts* and *timeout* into one stop condition.
     """
     stops = []
 
-    if attempts:
+    if attempts is not None:
         stops.append(_t.stop_after_attempt(attempts))
 
-    if timeout:
+    if timeout is not None:
         stops.append(_t.stop_after_delay(timeout))
 
-    if len(stops) > 1:
-        return _t.stop_any(*stops)
-
     if not stops:
-        return _t.stop_never
+        unbounded_stop_condition = "Unbounded stop condition, use `timeout=float('inf')` to intentionally retry forever"
+        raise ValueError(unbounded_stop_condition)
 
-    return stops[0]
+    return _t.stop_any(*stops)
 
 
 def retry(

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -726,6 +726,10 @@ def retry(
     .. versionadded:: 23.3.0 `Trio <https://trio.readthedocs.io/>`_ support.
 
     .. versionadded:: 24.3.0 *on* can be a callable now.
+
+    .. versionchanged:: 25.2.0
+       Stop condition required, either *attempts* or *timeout* must be specified.
+
     """
     retry_ctx = _RetryContextIterator.from_params(
         on=on,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -49,7 +49,7 @@ async def test_ok(attempts, timeout, duration):
     assert 42 == await C().f()
 
 
-@pytest.mark.parametrize("timeout", [None, 0, 1, dt.timedelta(days=1)])
+@pytest.mark.parametrize("timeout", [None, 1, dt.timedelta(days=1)])
 @pytest.mark.parametrize("duration", [0, dt.timedelta(days=0)])
 async def test_retries(duration, timeout, on):
     """

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,8 +12,8 @@ import stamina
 pytestmark = pytest.mark.anyio
 
 
-@pytest.mark.parametrize("attempts", [None, 1])
-@pytest.mark.parametrize("timeout", [None, 1, dt.timedelta(days=1)])
+@pytest.mark.parametrize("attempts", [None, -1, 0, 1])
+@pytest.mark.parametrize("timeout", [None, -1, 0, 1, dt.timedelta(days=1)])
 @pytest.mark.parametrize("duration", [1, dt.timedelta(days=1)])
 async def test_ok(attempts, timeout, duration):
     """
@@ -49,7 +49,7 @@ async def test_ok(attempts, timeout, duration):
     assert 42 == await C().f()
 
 
-@pytest.mark.parametrize("timeout", [None, 1, dt.timedelta(days=1)])
+@pytest.mark.parametrize("timeout", [None, 0, 1, dt.timedelta(days=1)])
 @pytest.mark.parametrize("duration", [0, dt.timedelta(days=0)])
 async def test_retries(duration, timeout, on):
     """

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -19,6 +19,8 @@ async def test_ok(attempts, timeout, duration):
     """
     No error, no problem.
     """
+    if attempts is None and timeout is None:
+        pytest.skip("Unbounded stop condition")
 
     class C:
         @stamina.retry(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -13,8 +13,8 @@ import stamina
 from stamina._core import _make_stop
 
 
-@pytest.mark.parametrize("attempts", [None, 1])
-@pytest.mark.parametrize("timeout", [None, 1, dt.timedelta(days=1)])
+@pytest.mark.parametrize("attempts", [None, -1, 0, 1])
+@pytest.mark.parametrize("timeout", [None, -1, 0, 1, dt.timedelta(days=1)])
 @pytest.mark.parametrize("duration", [1, dt.timedelta(days=1)])
 def test_ok(attempts, timeout, duration):
     """

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -21,6 +21,8 @@ def test_ok(attempts, timeout, duration):
     """
     No error, no problem.
     """
+    if attempts is None and timeout is None:
+        pytest.skip("Unbounded stop condition")
 
     @stamina.retry(
         on=Exception,
@@ -228,9 +230,12 @@ def test_testing_mode():
 class TestMakeStop:
     def test_never(self):
         """
-        If all conditions are None, return stop_never.
+        If all conditions are None, error.
         """
-        assert tenacity.stop_never is _make_stop(attempts=None, timeout=None)
+        with pytest.raises(ValueError):
+            _make_stop(attempts=None, timeout=None)
+
+        _make_stop(attempts=None, timeout=float("inf"))
 
 
 class TestRetryingCaller:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,7 +7,6 @@ import datetime as dt
 from types import SimpleNamespace
 
 import pytest
-import tenacity
 
 import stamina
 


### PR DESCRIPTION
# Summary

Raise `ValueError` when *attempts* and *timeout* are both `None` to prevent unbounded stop conditions.

This also fixes less intuitive scenario previously where `attempts=0, timeout=0.0` also caused unbounded stop condition.

Aligns with part of motivation from docs:

> You must not retry forever. Sometimes, a remote service is down indefinitely, and you must deal with it.

Discussed in https://github.com/hynek/stamina/discussions/99


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/stamina/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/stamina/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.md` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).

      The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/stamina/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->

