### PR TITLE
Allow predicates to return floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   If supporting these features causes problems, they may be removed again in a future version.
   [#123](https://github.com/hynek/stamina/pull/123)
 
-- An *on* predicate can now return a float or a `datetime.timedelta` to specify a custom backoff that overrides the default backoff.
+- An *on* hook can now return a float or a `datetime.timedelta` to specify a custom backoff that overrides the default backoff.
   [#103](https://github.com/hynek/stamina/discussions/103)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - An *on* hook can now return a float or a `datetime.timedelta` to specify a custom backoff that overrides the default backoff.
   [#103](https://github.com/hynek/stamina/discussions/103)
+  [#125](https://github.com/hynek/stamina/pull/125)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   If supporting these features causes problems, they may be removed again in a future version.
   [#123](https://github.com/hynek/stamina/pull/123)
 
+- An *on* predicate can now return a float to specify a custom backoff that overrides the default backoff.
+  [#103](https://github.com/hynek/stamina/discussions/103)
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   If supporting these features causes problems, they may be removed again in a future version.
   [#123](https://github.com/hynek/stamina/pull/123)
 
-- An *on* predicate can now return a float to specify a custom backoff that overrides the default backoff.
+- An *on* predicate can now return a float or a `datetime.timedelta` to specify a custom backoff that overrides the default backoff.
   [#103](https://github.com/hynek/stamina/discussions/103)
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ But bad retries can make things *much worse*.
 Our goal is to be as **ergonomic** as possible, while doing the **right thing by default**, and minimizing the potential for **misuse**.
 It is the result of years of copy-pasting the same configuration over and over again:
 
-- Retry only on certain exceptions – or even a subset of them by introspecting them first using a predicate.
+- Retry only on certain exceptions – or even a subset of them by introspecting them first using a backoff hook.
 - Exponential **backoff** with **jitter** between retries.
 - Limit the number of retries **and** total time.
 - Automatic **async** support – including [Trio](https://trio.readthedocs.io/).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ def do_it(code: int) -> httpx.Response:
     return resp
 ```
 
-If you need more control, you can return a float or a {class}`datetime.timedelta` to specify a custom backoff that overrides the default backoff instead of a boolean.
+If you need more control, you can return a {class}`float` of seconds or a {class}`datetime.timedelta` to specify a custom backoff that overrides the default backoff instead of a boolean.
 This is useful when the error carries information like a [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header.
 A custom backoff is **not** part of the exponential backoff machinery so none of the other backoff parameters apply to it.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -35,8 +35,8 @@ Sometimes, an exception is too broad, though.
 For example, *httpx* raises [`httpx.HTTPStatusError`](https://www.python-httpx.org/exceptions/) on all HTTP errors.
 But some errors, like 404 (Not Found) or 403 (Forbidden), usually shouldn't be retried!
 
-To solve problems like this, you can pass a *predicate* to `on`.
-A predicate is a callable that's called with the exception that was raised and whose return value will be used to decide whether to retry or not.
+To solve problems like this, you can pass a *backoff hook* to `on`.
+A backoff hook is a callable that's called with the exception that was raised and whose return value will be used to decide whether to retry or not.
 
 So, calling the following `do_it` function will only retry if <https://httpbin.org> returns a 5xx status code:
 
@@ -56,6 +56,10 @@ def do_it(code: int) -> httpx.Response:
 
     return resp
 ```
+
+If you need more control, you can return a float or a {class}`datetime.timedelta` to specify a custom backoff that overrides the default backoff instead of a boolean.
+This is useful when the error carries information like a [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header.
+A custom backoff is **not** part of the exponential backoff machinery so none of the other backoff parameters apply to it.
 
 ---
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -759,7 +759,7 @@ def retry(  # noqa: C901
             For even more control, the predicate may return a float or a
             `datetime.timedelta` to specify a custom backoff that overrides the
             default backoff. This is useful when the error carries information
-            like an ``Retry-After`` header.
+            like a ``Retry-After`` header.
 
             There is no default -- you *must* pass *on* explicitly.
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -97,7 +97,9 @@ class _TenacityBackoffCallbackAdapter:
                     "Backoff hooks must return a bool or a float or a timedelta. "
                     "This will be an error in a future version."
                 ),
-                stacklevel=2,
+                # Since we get called from Tenacity and not from user code, the
+                # stack is meaningless.
+                stacklevel=1,
             )
             return False
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -612,8 +612,8 @@ class _RetryContextIterator:
         """
         Compute the backoff for *rcs*.
 
-        If a custom backoff was provided by a predicate, use it. Otherwise, use
-        exponential backoff.
+        If a custom backoff was provided by a backoff hook, use it. Otherwise,
+        use exponential backoff.
         """
         if (
             custom_backoff := getattr(rcs, _CUSTOM_BACKOFF_ATTR, None)

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import datetime as dt
 import random
+import warnings
 
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from contextlib import AbstractContextManager
@@ -88,6 +89,17 @@ class _TenacityBackoffCallbackAdapter:
             return False
 
         result = self._backoff_hook(exc)
+
+        if result is None:
+            warnings.warn(
+                (
+                    f"Backoff hook {self._backoff_hook!r} returned None. "
+                    "Backoff hooks must return a bool or a float or a timedelta. "
+                    "This will be an error in a future version."
+                ),
+                stacklevel=2,
+            )
+            return False
 
         if isinstance(result, bool):
             return result

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -58,7 +58,7 @@ async def _smart_sleep(delay: float) -> None:
 
 T = TypeVar("T")
 P = ParamSpec("P")
-Predicate: TypeAlias = Callable[[Exception], bool | float]
+Predicate: TypeAlias = Callable[[Exception], bool | float | dt.timedelta]
 ExcOrPredicate: TypeAlias = (
     type[Exception] | tuple[type[Exception], ...] | Predicate
 )
@@ -89,6 +89,9 @@ class _PredicateRetry:
 
         if isinstance(result, bool):
             return result
+
+        if isinstance(result, dt.timedelta):
+            result = result.total_seconds()
 
         setattr(retry_state, _CUSTOM_BACKOFF_KEY, result)
         return True
@@ -753,9 +756,10 @@ def retry(  # noqa: C901
             indicate server errors, but not those in the 400s which indicate a
             client error.
 
-            For even more control, the predicate may return a float to specify
-            a custom backoff that overrides the default backoff. This is useful
-            when the error carries information like an ``Retry-After`` header.
+            For even more control, the predicate may return a float or a
+            `datetime.timedelta` to specify a custom backoff that overrides the
+            default backoff. This is useful when the error carries information
+            like an ``Retry-After`` header.
 
             There is no default -- you *must* pass *on* explicitly.
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -761,14 +761,19 @@ def retry(  # noqa: C901
             indicate server errors, but not those in the 400s which indicate a
             client error.
 
-            For even more control, the hook may return a float or a
-            `datetime.timedelta` to specify a custom backoff that overrides the
-            default backoff. This is useful when the error carries information
-            like a ``Retry-After`` header. A custom backoff is not part of the
-            exponential backoff machinery so none of the other backoff
-            parameters apply to it.
 
-            There is no default -- you *must* pass *on* explicitly.
+            For even more control, the hook may return a float or a
+            :class:`datetime.timedelta` to specify a custom backoff that
+            overrides the default backoff. This is useful when the error
+            carries information like a `Retry-After
+            <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After>`_
+            header. A custom backoff is not part of the exponential backoff
+            machinery so none of the other backoff parameters apply to it.
+
+
+            There is no default for the *on* parameter -- you *must* pass *on*
+            explicitly.
+
 
         attempts:
             Maximum total number of attempts. Can be combined with *timeout*.
@@ -800,8 +805,9 @@ def retry(  # noqa: C901
        Generator functions and async generator functions are now retried, too.
 
     .. versionadded:: 25.2.0
-       An *on* predicate can now return a float to specify a custom backoff
-       that overrides the default backoff.
+       An *on* backoff hook can now return a float or a `datetime.timedelta` to
+       specify a custom backoff that overrides the default backoff.
+
     """
     retry_ctx = _RetryContextIterator.from_params(
         on=on,

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -63,8 +63,8 @@ ExcOrPredicate: TypeAlias = (
     type[Exception] | tuple[type[Exception], ...] | Predicate
 )
 
-# Key used to store custom backoff in RetryCallState
-_CUSTOM_BACKOFF_KEY = "_stamina_custom_backoff"
+# Attribute used to store custom backoff in RetryCallState
+_CUSTOM_BACKOFF_ATTR = "_stamina_custom_backoff"
 
 
 class _PredicateRetry:
@@ -93,7 +93,7 @@ class _PredicateRetry:
         if isinstance(result, dt.timedelta):
             result = result.total_seconds()
 
-        setattr(retry_state, _CUSTOM_BACKOFF_KEY, result)
+        setattr(retry_state, _CUSTOM_BACKOFF_ATTR, result)
         return True
 
 
@@ -599,9 +599,9 @@ class _RetryContextIterator:
         exponential backoff.
         """
         if (
-            custom_backoff := getattr(rcs, _CUSTOM_BACKOFF_KEY, None)
+            custom_backoff := getattr(rcs, _CUSTOM_BACKOFF_ATTR, None)
         ) is not None:
-            delattr(rcs, _CUSTOM_BACKOFF_KEY)
+            delattr(rcs, _CUSTOM_BACKOFF_ATTR)
 
             if CONFIG.testing is not None:
                 return 0.0

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -592,8 +592,8 @@ class _RetryContextIterator:
         """
         Compute the backoff for *rcs*.
 
-        If a custom backoff was provided by a predicate, use it (clamped to
-        *wait_max*). Otherwise, use exponential backoff.
+        If a custom backoff was provided by a predicate, use it. Otherwise, use
+        exponential backoff.
         """
         if (
             custom_backoff := getattr(rcs, _CUSTOM_BACKOFF_KEY, None)
@@ -603,7 +603,7 @@ class _RetryContextIterator:
             if CONFIG.testing is not None:
                 return 0.0
 
-            return min(self._wait_max, cast(float, custom_backoff))
+            return cast(float, custom_backoff)
 
         return _compute_backoff(
             rcs.attempt_number,
@@ -756,7 +756,6 @@ def retry(  # noqa: C901
             For even more control, the predicate may return a float to specify
             a custom backoff that overrides the default backoff. This is useful
             when the error carries information like an ``Retry-After`` header.
-            This custom backoff is clamped to *wait_max*.
 
             There is no default -- you *must* pass *on* explicitly.
 

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -761,7 +761,6 @@ def retry(  # noqa: C901
             indicate server errors, but not those in the 400s which indicate a
             client error.
 
-
             For even more control, the hook may return a float or a
             :class:`datetime.timedelta` to specify a custom backoff that
             overrides the default backoff. This is useful when the error
@@ -770,10 +769,8 @@ def retry(  # noqa: C901
             header. A custom backoff is not part of the exponential backoff
             machinery so none of the other backoff parameters apply to it.
 
-
             There is no default for the *on* parameter -- you *must* pass *on*
             explicitly.
-
 
         attempts:
             Maximum total number of attempts. Can be combined with *timeout*.

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -752,7 +752,7 @@ def retry(  # noqa: C901
             An Exception or a tuple of Exceptions on which the decorated
             callable will be retried.
 
-            You can also pass a *predicate* in the form of a callable that
+            You can also pass a *backoff hook* in the form of a callable that
             takes an exception and returns a bool which decides whether the
             exception should be retried -- True meaning yes.
 
@@ -761,10 +761,12 @@ def retry(  # noqa: C901
             indicate server errors, but not those in the 400s which indicate a
             client error.
 
-            For even more control, the predicate may return a float or a
+            For even more control, the hook may return a float or a
             `datetime.timedelta` to specify a custom backoff that overrides the
             default backoff. This is useful when the error carries information
-            like a ``Retry-After`` header.
+            like a ``Retry-After`` header. A custom backoff is not part of the
+            exponential backoff machinery so none of the other backoff
+            parameters apply to it.
 
             There is no default -- you *must* pass *on* explicitly.
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -576,12 +576,12 @@ class TestAsyncGeneratorFunctionDecoration:
         assert 1 == num_called
 
 
-class TestPredicateBackoffAsync:
+class TestBackoffHookAsync:
     @pytest.mark.anyio
     @pytest.mark.usefixtures("anyio_backend")
-    async def test_predicate_returns_float_async(self):
+    async def test_backoff_hook_returns_float_async(self):
         """
-        Predicates returning float work with async functions.
+        If a backoff hook returns a float, it is used as the backoff duration.
         """
         attempts = 0
 
@@ -603,9 +603,9 @@ class TestPredicateBackoffAsync:
 
     @pytest.mark.anyio
     @pytest.mark.usefixtures("anyio_backend")
-    async def test_predicate_with_async_retry_context(self):
+    async def test_backoff_hook_with_async_retry_context(self):
         """
-        Predicate backoffs work with async retry_context.
+        Backoff hooks work with async retry_context.
         """
         attempts = 0
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -623,28 +623,6 @@ class TestPredicateBackoffSync:
         assert 2 == attempts
         assert duration < 5
 
-    def test_predicate_backoff_respects_wait_max(self):
-        """
-        Custom backoff values are clamped to wait_max.
-        """
-        attempts = 0
-
-        @stamina.retry(on=lambda exc: 100.0, attempts=3, wait_max=0)
-        def f():
-            nonlocal attempts
-            attempts += 1
-            if attempts < 2:
-                raise ValueError("retry")
-            return 42
-
-        started_at = time.perf_counter()
-        result = f()
-        duration = time.perf_counter() - started_at
-
-        assert 42 == result
-        assert 2 == attempts
-        assert duration < 1
-
     def test_predicate_with_retry_context(self):
         """
         Predicate backoffs work with retry_context.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -548,8 +548,8 @@ class CustomBackoffError(Exception):
         super().__init__(f"Retry after {backoff}s")
 
 
-class TestPredicateBackoffSync:
-    def test_predicate_backoff_in_test_mode_returns_zero(self):
+class TestBackoffHookSync:
+    def test_backoff_hook_in_test_mode_returns_zero(self):
         """
         In test mode, custom backoffs are ignored.
         """
@@ -573,9 +573,9 @@ class TestPredicateBackoffSync:
         assert 3 == attempts
         assert duration < 0.1
 
-    def test_predicate_returns_float(self):
+    def test_backoff_hook_returns_float(self):
         """
-        Predicates returning a float use that as the backoff duration.
+        If a backoff hook returns a float, it is used as the backoff duration.
         """
         attempts = 0
 
@@ -595,9 +595,9 @@ class TestPredicateBackoffSync:
         assert 3 == attempts
         assert duration < 5
 
-    def test_predicate_returns_timedelta(self):
+    def test_backoff_hook_returns_timedelta(self):
         """
-        Predicates returning a timedelta use that as the backoff duration.
+        If a backoff hook returns a timedelta, it is used as the backoff duration.
         """
         attempts = 0
 
@@ -619,18 +619,18 @@ class TestPredicateBackoffSync:
         assert 2 == attempts
         assert duration < 1
 
-    def test_predicate_custom_backoff_from_exception(self):
+    def test_backoff_hook_custom_backoff_from_exception(self):
         """
-        Predicates can extract backoff from exception attributes.
+        A backoff hook can extract a custombackoff from exception attributes.
         """
         attempts = 0
 
-        def predicate(exc):
+        def hook(exc):
             if isinstance(exc, CustomBackoffError):
                 return exc.backoff
             return False
 
-        @stamina.retry(on=predicate, attempts=3, wait_initial=5)
+        @stamina.retry(on=hook, attempts=3, wait_initial=5)
         def f():
             nonlocal attempts
             attempts += 1
@@ -647,9 +647,9 @@ class TestPredicateBackoffSync:
         assert 2 == attempts
         assert duration < 5
 
-    def test_predicate_with_retry_context(self):
+    def test_backoff_hook_with_retry_context(self):
         """
-        Predicate backoffs work with retry_context.
+        Backoff hooks work with retry_context.
         """
         attempts = 0
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -595,6 +595,30 @@ class TestPredicateBackoffSync:
         assert 3 == attempts
         assert duration < 5
 
+    def test_predicate_returns_timedelta(self):
+        """
+        Predicates returning a timedelta use that as the backoff duration.
+        """
+        attempts = 0
+
+        @stamina.retry(
+            on=lambda exc: dt.timedelta(seconds=0), wait_initial=5, attempts=3
+        )
+        def f():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 2:
+                raise ValueError("retry")
+            return 42
+
+        started_at = time.perf_counter()
+        result = f()
+        duration = time.perf_counter() - started_at
+
+        assert 42 == result
+        assert 2 == attempts
+        assert duration < 1
+
     def test_predicate_custom_backoff_from_exception(self):
         """
         Predicates can extract backoff from exception attributes.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -666,3 +666,21 @@ class TestBackoffHookSync:
 
         assert 2 == attempts
         assert duration < 5
+
+    def test_backoff_hook_returns_none(self):
+        """
+        If a backoff hook returns None, it is treated as False and a warning is
+        raised.
+        """
+
+        @stamina.retry(on=lambda exc: None, attempts=3)
+        def f():
+            raise ValueError("retry")
+
+        with pytest.raises(ValueError), pytest.warns() as ws:
+            f()
+
+        msg = ws.pop().message.args[0]
+
+        assert "Backoff hook" in msg
+        assert "lambda" in msg


### PR DESCRIPTION
This PR adds the ability for predicates to return a float instead of a bool. This allows to extract the backoff time from errors like 429 HTTP errors.

We piggy-back on top of Tenacity's retry state to avoid own global state – dunno if there's a more elegant way?

There's one big question for me: should stamina clamp the return value or not? Currently it does, because it feels like it would be surprising for the user if wait_max were exceeded, OTOH it feels like overriding an explicit wish?

cc @danielballan @jayqi