### PR TITLE
Fix OverflowError in _compute_backoff for high attempt numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `_compute_backoff()` no longer raises `OverflowError` when the attempt number exceeds 1024 with a float *wait_exp_base*.
   The exponential result is now clamped to *wait_max* on overflow.
-  [#104](https://github.com/hynek/stamina/issues/104)
+  [#104](https://github.com/hynek/stamina/issues/137)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/stamina/compare/25.2.0...HEAD)
 
+### Fixed
+
+- `_compute_backoff()` no longer raises `OverflowError` when the attempt number exceeds 1024 with a float *wait_exp_base*.
+  The exponential result is now clamped to *wait_max* on overflow.
+  [#104](https://github.com/hynek/stamina/issues/104)
+
+
 ### Changed
 
 - Passing `timeout=0` now raises a warning since it counterintuitively disables all retries.

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -658,7 +658,12 @@ def _compute_backoff(
 
     jitter = random.uniform(0, max_jitter) if max_jitter else 0  # noqa: S311
 
-    return min(max_backoff, initial * (exp_base ** (num - 1)) + jitter)
+    try:
+        return min(
+            max_backoff, initial * (exp_base ** (num - 1)) + jitter
+        )
+    except OverflowError:
+        return max_backoff
 
 
 def _make_before_sleep(

--- a/src/stamina/_core.py
+++ b/src/stamina/_core.py
@@ -659,9 +659,7 @@ def _compute_backoff(
     jitter = random.uniform(0, max_jitter) if max_jitter else 0  # noqa: S311
 
     try:
-        return min(
-            max_backoff, initial * (exp_base ** (num - 1)) + jitter
-        )
+        return min(max_backoff, initial * (exp_base ** (num - 1)) + jitter)
     except OverflowError:
         return max_backoff
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -228,6 +228,29 @@ def test_backoff_computation_clamps():
         assert jittered <= 0.42
 
 
+def test_backoff_no_overflow_on_high_attempt_numbers():
+    """
+    Exponential backoff with a float base does not raise OverflowError when
+    the attempt number exceeds 1024.
+
+    Regression test for https://github.com/hynek/stamina/issues/104.
+    """
+    rci = stamina.retry_context(
+        on=ValueError, wait_max=5.0, attempts=None, timeout=None
+    )
+
+    for num in (1025, 2000, 10_000):
+        backoff = rci._backoff_for_attempt_number(num)
+
+        assert 5.0 == backoff
+
+        jittered = rci._jittered_backoff_for_rcs(
+            SimpleNamespace(attempt_number=num)
+        )
+
+        assert jittered <= 5.0
+
+
 def test_testing_mode():
     """
     Testing mode can be set and reset.


### PR DESCRIPTION
# Summary

Fixes #104.

When retrying with the default float `wait_exp_base=2.0`, Python's `float` overflows at attempt 1025 (`2.0 ** 1024` exceeds `sys.float_info.max`), causing an `OverflowError` in `_compute_backoff()`.

This is a real-world problem when `wait_max` is set (e.g. 5 seconds) and retries run for extended periods — 1024 attempts with a 5-second cap is reached in roughly 85 minutes.

**Root cause:** `initial * (exp_base ** (num - 1))` overflows for float bases when `num > 1024`.

**Fix:** Catch `OverflowError` and return `max_backoff`. Any value that overflows Python's float necessarily exceeds `max_backoff`, so clamping is correct.

# Pull Request Check List

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
- [x] Added **tests** for changed code.
    - Added `test_backoff_no_overflow_on_high_attempt_numbers` that verifies attempts 1025, 2000, and 10,000 return `max_backoff` without raising.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/stamina/blob/main/tests/typing/api.py).
    - N/A — no new public APIs.
- [x] Updated **documentation** for changed code.
    - [x] N/A — no new functions/classes.
    - [x] N/A — no changed public API signatures.
- [x] Documentation in `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/stamina/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.